### PR TITLE
Add state code field

### DIFF
--- a/src/ikea_api/core.py
+++ b/src/ikea_api/core.py
@@ -57,7 +57,7 @@ class IkeaApi:
             self._cart = Cart(self._token)
         return self._cart
 
-    def OrderCapture(self, zip_code: str, state_code: str = ""):
+    def OrderCapture(self, zip_code: str, state_code: str | None = None):
         """Get available delivery services. Object is callable."""
         from ikea_api.endpoints import OrderCapture
 

--- a/src/ikea_api/core.py
+++ b/src/ikea_api/core.py
@@ -57,11 +57,11 @@ class IkeaApi:
             self._cart = Cart(self._token)
         return self._cart
 
-    def OrderCapture(self, zip_code: str):
+    def OrderCapture(self, zip_code: str, state_code: str = ""):
         """Get available delivery services. Object is callable."""
         from ikea_api.endpoints import OrderCapture
 
-        return OrderCapture(self._token, zip_code)()
+        return OrderCapture(self._token, zip_code, state_code)()
 
     @property
     def Purchases(self):

--- a/src/ikea_api/endpoints/order_capture/__init__.py
+++ b/src/ikea_api/endpoints/order_capture/__init__.py
@@ -10,7 +10,7 @@ from ikea_api.errors import IkeaApiError, OrderCaptureError
 
 
 class OrderCapture(API):
-    def __init__(self, token: str, zip_code: str | int):
+    def __init__(self, token: str, zip_code: str | int, state_code: str):
         super().__init__(token, "https://ordercapture.ikea.ru/ordercaptureapi/ru")
 
         if Constants.COUNTRY_CODE != "ru":
@@ -22,6 +22,10 @@ class OrderCapture(API):
         zip_code = str(zip_code)
         validate_zip_code(zip_code)
         self._zip_code = zip_code
+
+        if state_code != "":
+            validate_state_code(state_code)
+        self._state_code = state_code
 
         self._session.headers["X-Client-Id"] = Secrets.purchases_x_client_id
 
@@ -79,7 +83,7 @@ class OrderCapture(API):
         """Generate delivery area for checkout from zip code"""
         response = self._call_api(
             endpoint=f"{self._endpoint}/checkouts/{checkout}/delivery-areas",
-            data={"zipCode": self._zip_code, "enableRangeOfDays": False},
+            data={"zipCode": self._zip_code, "enableRangeOfDays": False, "stateCode": self._state_code},
         )
 
         if "resourceId" in response:
@@ -102,3 +106,8 @@ class OrderCapture(API):
 def validate_zip_code(zip_code: str | int):
     if len(re.findall(r"[^0-9]", str(zip_code))) > 0:
         raise ValueError(f"Invalid zip code: {zip_code}")
+
+
+def validate_state_code(state_code: str):
+    if state_code.isdigit() or len(state_code) != 2:
+        raise ValueError(f"Invalid state code: {state_code}")


### PR DESCRIPTION
This PR adds a field state code which is necessary when capturing orders in the US.

Before this change, trying to use OrderCapture with country_code="us" would throw an error due to the missing stateCode.

After this change, the user can pass the state code along with the zip code, for example:

`api.OrderCapture(zip_code="02215", state_code="MA")`

The [state code](https://www.census.gov/library/reference/code-lists/ansi/ansi-codes-for-states.html) validator takes into account that all state codes should have two letters. state_code string is not case sensitive.

If no state code is specified, an empty string is passed, which does not affect non-US country codes.

It has been tested with US state codes, I am not aware if there are other countries for which IKEA requires state codes.  

Closes #33 