### PR TITLE
Use language code from constants in order capture

### DIFF
--- a/src/ikea_api/endpoints/order_capture/__init__.py
+++ b/src/ikea_api/endpoints/order_capture/__init__.py
@@ -63,7 +63,7 @@ class OrderCapture(API):
             "shoppingType": "ONLINE",
             "channel": "WEBAPP",
             "checkoutType": "STANDARD",
-            "languageCode": "ru",
+            "languageCode": Constants.LANGUAGE_CODE,
             "items": items,
             "deliveryArea": None,
         }


### PR DESCRIPTION
This change simply uses the language code from the constants in the "OrderCapture" class. The hard-coded "ru" value does not work for the Swedish version of the API, and the change should not create any further issues since the language code used in other parts of the world should be valid a language code for the corresponding order capture api.

closes #39.