### PR TITLE
Fix not exported symbols issue

### DIFF
--- a/src/ikea_api/__init__.py
+++ b/src/ikea_api/__init__.py
@@ -1,16 +1,16 @@
 from ikea_api.constants import Constants as Constants
-from ikea_api.endpoints.auth import API as Auth
-from ikea_api.endpoints.cart import API as Cart
-from ikea_api.endpoints.ingka_items import API as IngkaItems
-from ikea_api.endpoints.iows_items import API as IowsItems
-from ikea_api.endpoints.order_capture import API as OrderCapture
+from ikea_api.endpoints.auth import Auth as Auth
+from ikea_api.endpoints.cart import Cart as Cart
+from ikea_api.endpoints.ingka_items import IngkaItems as IngkaItems
+from ikea_api.endpoints.iows_items import IowsItems as IowsItems
+from ikea_api.endpoints.order_capture import OrderCapture as OrderCapture
 from ikea_api.endpoints.order_capture import (
     convert_cart_to_checkout_items as convert_cart_to_checkout_items,
 )
-from ikea_api.endpoints.pip_item import API as PipItem
-from ikea_api.endpoints.purchases import API as Purchases
-from ikea_api.endpoints.search import API as Search
-from ikea_api.endpoints.stock import API as Stock
+from ikea_api.endpoints.pip_item import PipItem as PipItem
+from ikea_api.endpoints.purchases import Purchases as Purchases
+from ikea_api.endpoints.search import Search as Search
+from ikea_api.endpoints.stock import Stock as Stock
 from ikea_api.exceptions import APIError as APIError
 from ikea_api.exceptions import AuthError as AuthError
 from ikea_api.exceptions import GraphQLError as GraphQLError
@@ -20,7 +20,7 @@ from ikea_api.exceptions import NotSuccessError as NotSuccessError
 from ikea_api.exceptions import ParsingError as ParsingError
 from ikea_api.exceptions import ProcessingError as ProcessingError
 from ikea_api.exceptions import WrongItemCodeError as WrongItemCodeError
-from ikea_api.executors.httpx import run as run_async
+from ikea_api.executors.httpx import run_async as run_async
 from ikea_api.executors.requests import run as run
 from ikea_api.utils import format_item_code as format_item_code
 from ikea_api.utils import parse_item_codes as parse_item_codes
@@ -29,5 +29,3 @@ from ikea_api.wrappers.wrappers import get_delivery_services as get_delivery_ser
 from ikea_api.wrappers.wrappers import get_items as get_items
 from ikea_api.wrappers.wrappers import get_purchase_history as get_purchase_history
 from ikea_api.wrappers.wrappers import get_purchase_info as get_purchase_info
-
-# pyright: reportUnusedImport = false

--- a/src/ikea_api/endpoints/auth.py
+++ b/src/ikea_api/endpoints/auth.py
@@ -7,7 +7,7 @@ from ikea_api.error_handlers import (
 )
 
 
-class API(BaseIkeaAPI):
+class Auth(BaseIkeaAPI):
     def _get_session_info(self) -> SessionInfo:
         url = "https://api.ingka.ikea.com/guest/token"
         headers = self._extend_default_headers(

--- a/src/ikea_api/endpoints/cart.py
+++ b/src/ikea_api/endpoints/cart.py
@@ -21,7 +21,7 @@ def convert_items(items: dict[str, int]) -> list[_TemplatedItem]:
     return [{"itemNo": item_code, "quantity": qty} for item_code, qty in items.items()]
 
 
-class API(BaseAuthIkeaAPI):
+class Cart(BaseAuthIkeaAPI):
     def _get_session_info(self) -> SessionInfo:
         url = "https://cart.oneweb.ingka.com/graphql"
         headers = self._extend_default_headers_with_auth(

--- a/src/ikea_api/endpoints/ingka_items.py
+++ b/src/ikea_api/endpoints/ingka_items.py
@@ -12,7 +12,7 @@ from ikea_api.error_handlers import (
 from ikea_api.exceptions import ItemFetchError
 
 
-class API(BaseIkeaAPI):
+class IngkaItems(BaseIkeaAPI):
     def _get_session_info(self):
         headers = self._extend_default_headers(
             {

--- a/src/ikea_api/endpoints/iows_items.py
+++ b/src/ikea_api/endpoints/iows_items.py
@@ -16,7 +16,7 @@ def _build_url(items: ItemCodeToComboDict) -> str:
     )
 
 
-class API(BaseIkeaAPI):
+class IowsItems(BaseIkeaAPI):
     items: ItemCodeToComboDict
 
     def _get_session_info(self) -> SessionInfo:

--- a/src/ikea_api/endpoints/order_capture.py
+++ b/src/ikea_api/endpoints/order_capture.py
@@ -21,7 +21,7 @@ class CheckoutItem(TypedDict):
 handlers = (handle_json_decode_error, handle_401, handle_not_success)
 
 
-class API(BaseAuthIkeaAPI):
+class OrderCapture(BaseAuthIkeaAPI):
     def _get_session_info(self) -> SessionInfo:
         host = "ikea.ru" if self._const.country == "ru" else "ingka.com"
         url = f"https://ordercapture.{host}/ordercaptureapi/{self._const.country}"

--- a/src/ikea_api/endpoints/pip_item.py
+++ b/src/ikea_api/endpoints/pip_item.py
@@ -7,7 +7,7 @@ from ikea_api.base_ikea_api import BaseIkeaAPI
 from ikea_api.error_handlers import handle_json_decode_error
 
 
-def _build_url(item_code: str, is_combination: bool) -> str:
+def build_url(item_code: str, is_combination: bool) -> str:
     prefix = "s" if is_combination else ""
     return f"/{item_code[5:]}/{prefix}{item_code}.json"
 
@@ -22,10 +22,10 @@ class PipItem(BaseIkeaAPI):
     def get_item(
         self, item_code: str, is_combination: bool = True
     ) -> Endpoint[dict[str, Any]]:
-        response = yield self._RequestInfo("GET", _build_url(item_code, is_combination))
+        response = yield self._RequestInfo("GET", build_url(item_code, is_combination))
 
         if response.status_code == 404 and is_combination:
-            response = yield self._RequestInfo("GET", _build_url(item_code, False))
+            response = yield self._RequestInfo("GET", build_url(item_code, False))
 
         handle_json_decode_error(response)
         return response.json

--- a/src/ikea_api/endpoints/pip_item.py
+++ b/src/ikea_api/endpoints/pip_item.py
@@ -12,7 +12,7 @@ def _build_url(item_code: str, is_combination: bool) -> str:
     return f"/{item_code[5:]}/{prefix}{item_code}.json"
 
 
-class API(BaseIkeaAPI):
+class PipItem(BaseIkeaAPI):
     def _get_session_info(self) -> SessionInfo:
         url = f"{self._const.local_base_url}/products"
         headers = self._extend_default_headers({"Accept": "*/*"})

--- a/src/ikea_api/endpoints/purchases.py
+++ b/src/ikea_api/endpoints/purchases.py
@@ -12,7 +12,7 @@ from ikea_api.error_handlers import (
 )
 
 
-def _build_payload(operation_name: str, query: str, **variables: Any) -> dict[str, Any]:
+def build_payload(operation_name: str, query: str, **variables: Any) -> dict[str, Any]:
     return {"operationName": operation_name, "variables": variables, "query": query}
 
 
@@ -42,7 +42,7 @@ class Purchases(BaseAuthIkeaAPI):
         """Get purchase history.
         Parameters are for pagination. If you want to see all your purchases set 'take' to 10000.
         """
-        payload = _build_payload("History", Queries.history, take=take, skip=skip)
+        payload = build_payload("History", Queries.history, take=take, skip=skip)
         response = yield self._RequestInfo("POST", json=payload)
         return response.json
 
@@ -72,7 +72,7 @@ class Purchases(BaseAuthIkeaAPI):
 
         if "StatusBannerOrder" in queries:
             payload.append(
-                _build_payload(
+                build_payload(
                     "StatusBannerOrder",
                     Queries.status_banner_order,
                     orderNumber=order_number,
@@ -80,13 +80,13 @@ class Purchases(BaseAuthIkeaAPI):
             )
         if "CostsOrder" in queries:
             payload.append(
-                _build_payload(
+                build_payload(
                     "CostsOrder", Queries.costs_order, orderNumber=order_number
                 )
             )
         if "ProductListOrder" in queries:
             payload.append(
-                _build_payload(
+                build_payload(
                     "ProductListOrder",
                     Queries.product_list_order,
                     orderNumber=order_number,

--- a/src/ikea_api/endpoints/purchases.py
+++ b/src/ikea_api/endpoints/purchases.py
@@ -24,7 +24,7 @@ handlers = (
 )
 
 
-class API(BaseAuthIkeaAPI):
+class Purchases(BaseAuthIkeaAPI):
     def _get_session_info(self) -> SessionInfo:
         url = "https://purchase-history.ocp.ingka.ikea.com/graphql"
         headers = self._extend_default_headers_with_auth(

--- a/src/ikea_api/endpoints/search.py
+++ b/src/ikea_api/endpoints/search.py
@@ -9,7 +9,7 @@ from ikea_api.error_handlers import handle_json_decode_error
 SearchType = Literal["PRODUCT", "CONTENT", "PLANNER", "REFINED_SEARCHES", "ANSWER"]
 
 
-class API(BaseIkeaAPI):
+class Search(BaseIkeaAPI):
     def _get_session_info(self) -> SessionInfo:
         url = f"https://sik.search.blue.cdtapps.com/{self._const.country}/{self._const.language}/search-result-page"
         return SessionInfo(base_url=url, headers=self._extend_default_headers({}))

--- a/src/ikea_api/endpoints/stock.py
+++ b/src/ikea_api/endpoints/stock.py
@@ -8,7 +8,7 @@ from ikea_api.error_handlers import handle_json_decode_error
 from ikea_api.exceptions import ItemFetchError
 
 
-class API(BaseIkeaAPI):
+class Stock(BaseIkeaAPI):
     def _get_session_info(self) -> SessionInfo:
         url = f"https://api.ingka.ikea.com/cia/availabilities/{self._const.country}/{self._const.language}"
         headers = self._extend_default_headers(

--- a/src/ikea_api/error_handlers.py
+++ b/src/ikea_api/error_handlers.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from json import JSONDecodeError
+import json
 from typing import Any, Dict, List, cast
 
 from ikea_api.abc import ResponseInfo
@@ -10,7 +10,7 @@ from ikea_api.exceptions import AuthError, GraphQLError, JSONError, NotSuccessEr
 def handle_json_decode_error(response: ResponseInfo) -> None:
     try:
         response.json
-    except JSONDecodeError:
+    except json.JSONDecodeError:
         raise JSONError(response)
 
 

--- a/src/ikea_api/executors/httpx.py
+++ b/src/ikea_api/executors/httpx.py
@@ -70,5 +70,5 @@ class HttpxExecutor(AsyncExecutor):
         return HttpxResponseInfo(response)
 
 
-async def run(endpoint: EndpointInfo[EndpointResponse]) -> EndpointResponse:
+async def run_async(endpoint: EndpointInfo[EndpointResponse]) -> EndpointResponse:
     return await HttpxExecutor.run(endpoint)

--- a/src/ikea_api/wrappers/parsers/ingka_items.py
+++ b/src/ikea_api/wrappers/parsers/ingka_items.py
@@ -175,7 +175,9 @@ def parse_item(constants: Constants, item: ResponseIngkaItem) -> types.IngkaItem
     )
 
 
-def main(constants: Constants, response: dict[str, Any]) -> Iterable[types.IngkaItem]:
+def parse_ingka_items(
+    constants: Constants, response: dict[str, Any]
+) -> Iterable[types.IngkaItem]:
     parsed_resp = ResponseIngkaItems(**response)
     for item in parsed_resp.data:
         yield parse_item(constants, item)

--- a/src/ikea_api/wrappers/parsers/iows_items.py
+++ b/src/ikea_api/wrappers/parsers/iows_items.py
@@ -205,7 +205,7 @@ def get_category_name_and_url(
     )
 
 
-def main(constants: Constants, response: Dict[str, Any]) -> types.ParsedItem:
+def parse_iows_item(constants: Constants, response: Dict[str, Any]) -> types.ParsedItem:
     response = get_rid_of_dollars(response)
     item = ResponseIowsItem(**response)
 

--- a/src/ikea_api/wrappers/parsers/order_capture.py
+++ b/src/ikea_api/wrappers/parsers/order_capture.py
@@ -269,12 +269,12 @@ def parse_collect_delivery_services(
     return res
 
 
-def main(
+def parse_delivery_services(
     *,
     constants: Constants,
-    home_delivery_services_response: dict[str, Any],
-    collect_delivery_services_response: dict[str, Any],
+    home_response: dict[str, Any],
+    collect_response: dict[str, Any],
 ) -> list[types.DeliveryService]:
     return parse_home_delivery_services(
-        constants, home_delivery_services_response
-    ) + parse_collect_delivery_services(constants, collect_delivery_services_response)
+        constants, home_response
+    ) + parse_collect_delivery_services(constants, collect_response)

--- a/src/ikea_api/wrappers/parsers/pip_item.py
+++ b/src/ikea_api/wrappers/parsers/pip_item.py
@@ -34,7 +34,7 @@ def get_category_name_and_url(catalog_refs: CatalogRefs):
     return catalog_refs.products.elements[0].name, catalog_refs.products.elements[0].url
 
 
-def main(response: dict[str, Any]) -> types.PipItem | None:
+def parse_pip_item(response: dict[str, Any]) -> types.PipItem | None:
     if not response:
         return
     parsed_item = ResponsePipItem(**response)

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -4,7 +4,7 @@ from tests.conftest import EndpointTester, MockResponseInfo
 
 
 def test_get_guest_token(constants: Constants):
-    c = EndpointTester(auth.API(constants).get_guest_token())
+    c = EndpointTester(auth.Auth(constants).get_guest_token())
 
     request_info = c.prepare()
     assert request_info.json == {"retailUnit": constants.country}

--- a/tests/endpoints/test_auth.py
+++ b/tests/endpoints/test_auth.py
@@ -1,10 +1,10 @@
 from ikea_api.constants import Constants
-from ikea_api.endpoints import auth
+from ikea_api.endpoints.auth import Auth
 from tests.conftest import EndpointTester, MockResponseInfo
 
 
 def test_get_guest_token(constants: Constants):
-    c = EndpointTester(auth.Auth(constants).get_guest_token())
+    c = EndpointTester(Auth(constants).get_guest_token())
 
     request_info = c.prepare()
     assert request_info.json == {"retailUnit": constants.country}

--- a/tests/endpoints/test_cart.py
+++ b/tests/endpoints/test_cart.py
@@ -4,7 +4,7 @@ import pytest
 
 from ikea_api.abc import EndpointInfo
 from ikea_api.constants import Constants
-from ikea_api.endpoints.cart import API, Mutations, Queries, convert_items
+from ikea_api.endpoints.cart import Cart, Mutations, Queries, convert_items
 from tests.conftest import EndpointTester
 
 in_items = {"11111111": 1, "22222222": 2}
@@ -20,10 +20,10 @@ def test_cart_convert_items():
 
 @pytest.fixture
 def cart(constants: Constants):
-    return API(constants, token="mytoken")  # nosec
+    return Cart(constants, token="mytoken")  # nosec
 
 
-def test_cart_req(cart: API):
+def test_cart_req(cart: Cart):
     query = "myquery"
     variables = {"ta": "da", "pa": "ga"}
 
@@ -47,24 +47,27 @@ def assert_req_called_with(endpoint: EndpointInfo[Any], query: str, **variables:
 @pytest.mark.parametrize(
     ("method", "query"),
     (
-        (API.show, Queries.cart),
-        (API.clear, Mutations.clear_items),
-        (API.clear_coupon, Mutations.clear_coupon),
+        (Cart.show, Queries.cart),
+        (Cart.clear, Mutations.clear_items),
+        (Cart.clear_coupon, Mutations.clear_coupon),
     ),
 )
-def test_cart_no_vars_methods(cart: API, method: Callable[..., Any], query: str):
+def test_cart_no_vars_methods(cart: Cart, method: Callable[..., Any], query: str):
     assert_req_called_with(method(cart), query)
 
 
 @pytest.mark.parametrize(
     ("method", "query"),
-    ((API.add_items, Mutations.add_items), (API.update_items, Mutations.update_items)),
+    (
+        (Cart.add_items, Mutations.add_items),
+        (Cart.update_items, Mutations.update_items),
+    ),
 )
-def test_cart_add_update_items(cart: API, method: Callable[..., Any], query: str):
+def test_cart_add_update_items(cart: Cart, method: Callable[..., Any], query: str):
     assert_req_called_with(method(cart, in_items), query, items=out_items)
 
 
-def test_cart_copy_items(cart: API):
+def test_cart_copy_items(cart: Cart):
     source_user_id = "myuserid"
     assert_req_called_with(
         cart.copy_items(source_user_id=source_user_id),
@@ -73,13 +76,13 @@ def test_cart_copy_items(cart: API):
     )
 
 
-def test_cart_remove_items(cart: API):
+def test_cart_remove_items(cart: Cart):
     item_codes = ["11111111"]
     assert_req_called_with(
         cart.remove_items(item_codes), Mutations.remove_items, itemNos=item_codes
     )
 
 
-def test_cart_set_coupon(cart: API):
+def test_cart_set_coupon(cart: Cart):
     code = "11"
     assert_req_called_with(cart.set_coupon(code), Mutations.set_coupon, code=code)

--- a/tests/endpoints/test_ingka_items.py
+++ b/tests/endpoints/test_ingka_items.py
@@ -4,13 +4,13 @@ import pytest
 
 from ikea_api import ItemFetchError
 from ikea_api.constants import Constants
-from ikea_api.endpoints import ingka_items
+from ikea_api.endpoints.ingka_items import IngkaItems
 from tests.conftest import EndpointTester, MockResponseInfo
 
 
 def test_ingka_items_passes(constants: Constants):
     item_codes = ["11111111", "22222222"]
-    t = EndpointTester(ingka_items.IngkaItems(constants).get_items(item_codes))
+    t = EndpointTester(IngkaItems(constants).get_items(item_codes))
 
     request_info = t.prepare()
     assert request_info.params == {"itemNos": item_codes}
@@ -33,7 +33,7 @@ def test_ingka_items_passes(constants: Constants):
     ),
 )
 def test_ingka_items_raises_no_item_code(constants: Constants, v: Any):
-    t = EndpointTester(ingka_items.IngkaItems(constants).get_items([]))
+    t = EndpointTester(IngkaItems(constants).get_items([]))
     with pytest.raises(ItemFetchError):
         t.parse(MockResponseInfo(json_=v))
 
@@ -51,6 +51,6 @@ def test_ingka_items_raises_with_item_code(constants: Constants):
             ],
         }
     }
-    t = EndpointTester(ingka_items.IngkaItems(constants).get_items([]))
+    t = EndpointTester(IngkaItems(constants).get_items([]))
     with pytest.raises(ItemFetchError):
         t.parse(MockResponseInfo(json_=v))

--- a/tests/endpoints/test_ingka_items.py
+++ b/tests/endpoints/test_ingka_items.py
@@ -10,7 +10,7 @@ from tests.conftest import EndpointTester, MockResponseInfo
 
 def test_ingka_items_passes(constants: Constants):
     item_codes = ["11111111", "22222222"]
-    t = EndpointTester(ingka_items.API(constants).get_items(item_codes))
+    t = EndpointTester(ingka_items.IngkaItems(constants).get_items(item_codes))
 
     request_info = t.prepare()
     assert request_info.params == {"itemNos": item_codes}
@@ -33,7 +33,7 @@ def test_ingka_items_passes(constants: Constants):
     ),
 )
 def test_ingka_items_raises_no_item_code(constants: Constants, v: Any):
-    t = EndpointTester(ingka_items.API(constants).get_items([]))
+    t = EndpointTester(ingka_items.IngkaItems(constants).get_items([]))
     with pytest.raises(ItemFetchError):
         t.parse(MockResponseInfo(json_=v))
 
@@ -51,6 +51,6 @@ def test_ingka_items_raises_with_item_code(constants: Constants):
             ],
         }
     }
-    t = EndpointTester(ingka_items.API(constants).get_items([]))
+    t = EndpointTester(ingka_items.IngkaItems(constants).get_items([]))
     with pytest.raises(ItemFetchError):
         t.parse(MockResponseInfo(json_=v))

--- a/tests/endpoints/test_iows_items.py
+++ b/tests/endpoints/test_iows_items.py
@@ -3,18 +3,18 @@ from typing import Any
 import pytest
 
 from ikea_api.constants import Constants
-from ikea_api.endpoints.iows_items import API
+from ikea_api.endpoints.iows_items import IowsItems
 from ikea_api.exceptions import ItemFetchError, WrongItemCodeError
 from tests.conftest import EndpointTester, MockResponseInfo
 
 
 @pytest.fixture
 def iows_items(constants: Constants):
-    return API(constants)
+    return IowsItems(constants)
 
 
 @pytest.fixture
-def iows_tester(iows_items: API):
+def iows_tester(iows_items: IowsItems):
     return EndpointTester(iows_items.get_items(["11111111"]))
 
 

--- a/tests/endpoints/test_order_capture.py
+++ b/tests/endpoints/test_order_capture.py
@@ -6,8 +6,8 @@ import pytest
 
 from ikea_api.constants import Constants
 from ikea_api.endpoints.order_capture import (
-    API,
     CheckoutItem,
+    OrderCapture,
     convert_cart_to_checkout_items,
 )
 from ikea_api.exceptions import ProcessingError
@@ -16,11 +16,11 @@ from tests.conftest import EndpointTester, MockResponseInfo
 
 @pytest.fixture
 def order_capture(constants: Constants):
-    return API(constants, token="mytoken")  # nosec
+    return OrderCapture(constants, token="mytoken")  # nosec
 
 
 @pytest.mark.parametrize("fail", (True, False))
-def test_get_checkout(order_capture: API, fail: bool):
+def test_get_checkout(order_capture: OrderCapture, fail: bool):
     items = [CheckoutItem(itemNo="11111111", quantity=1, uom="PIECE")]
     t = EndpointTester(order_capture.get_checkout(items))
 
@@ -42,7 +42,7 @@ def test_get_checkout(order_capture: API, fail: bool):
 
 
 @pytest.mark.parametrize("state_code", (None, "mystate"))
-def test_get_service_area_prepare(order_capture: API, state_code: str | None):
+def test_get_service_area_prepare(order_capture: OrderCapture, state_code: str | None):
     checkout_id = "mycheckout"
     zip_code = "101000"
     t = EndpointTester(
@@ -59,7 +59,7 @@ def test_get_service_area_prepare(order_capture: API, state_code: str | None):
 
 
 @pytest.mark.parametrize("fail", (True, False))
-def test_get_service_area_parse(order_capture: API, fail: bool):
+def test_get_service_area_parse(order_capture: OrderCapture, fail: bool):
     t = EndpointTester(order_capture.get_service_area("", ""))
 
     if fail:
@@ -73,11 +73,13 @@ def test_get_service_area_parse(order_capture: API, fail: bool):
 @pytest.mark.parametrize(
     ("method", "path"),
     (
-        (API.get_home_delivery_services, "home-delivery-services"),
-        (API.get_collect_delivery_services, "collect-delivery-services"),
+        (OrderCapture.get_home_delivery_services, "home-delivery-services"),
+        (OrderCapture.get_collect_delivery_services, "collect-delivery-services"),
     ),
 )
-def test_get_services(order_capture: API, method: Callable[..., Any], path: str):
+def test_get_services(
+    order_capture: OrderCapture, method: Callable[..., Any], path: str
+):
     checkout_id = "mycheckout"
     service_area_id = "myarea"
 

--- a/tests/endpoints/test_pip_item.py
+++ b/tests/endpoints/test_pip_item.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ikea_api.constants import Constants
-from ikea_api.endpoints.pip_item import API, _build_url
+from ikea_api.endpoints.pip_item import PipItem, _build_url
 from ikea_api.exceptions import APIError
 from tests.conftest import EndpointTester, MockResponseInfo
 
@@ -19,10 +19,10 @@ def test_build_url(item_code: str, is_combination: bool, expected: str):
 
 @pytest.fixture
 def pip_item(constants: Constants):
-    return API(constants)
+    return PipItem(constants)
 
 
-def test_pip_item_prepare(pip_item: API):
+def test_pip_item_prepare(pip_item: PipItem):
     item_code = "11111111"
     is_combination = False
     t = EndpointTester(pip_item.get_item(item_code, is_combination))
@@ -31,7 +31,7 @@ def test_pip_item_prepare(pip_item: API):
     assert req.url == _build_url(item_code, is_combination)
 
 
-def test_pip_item_no_retry(pip_item: API):
+def test_pip_item_no_retry(pip_item: PipItem):
     item_code = "11111111"
     is_combination = False
     t = EndpointTester(pip_item.get_item(item_code, is_combination))
@@ -41,7 +41,7 @@ def test_pip_item_no_retry(pip_item: API):
         t.parse(MockResponseInfo(status_code=404))
 
 
-def test_pip_item_retry(pip_item: API):
+def test_pip_item_retry(pip_item: PipItem):
     item_code = "11111111"
     is_combination = True
     t = EndpointTester(pip_item.get_item(item_code, is_combination))

--- a/tests/endpoints/test_pip_item.py
+++ b/tests/endpoints/test_pip_item.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ikea_api.constants import Constants
-from ikea_api.endpoints.pip_item import PipItem, _build_url
+from ikea_api.endpoints.pip_item import PipItem, build_url
 from ikea_api.exceptions import APIError
 from tests.conftest import EndpointTester, MockResponseInfo
 
@@ -14,7 +14,7 @@ from tests.conftest import EndpointTester, MockResponseInfo
     ),
 )
 def test_build_url(item_code: str, is_combination: bool, expected: str):
-    assert _build_url(item_code, is_combination) == expected
+    assert build_url(item_code, is_combination) == expected
 
 
 @pytest.fixture
@@ -28,7 +28,7 @@ def test_pip_item_prepare(pip_item: PipItem):
     t = EndpointTester(pip_item.get_item(item_code, is_combination))
     req = t.prepare()
 
-    assert req.url == _build_url(item_code, is_combination)
+    assert req.url == build_url(item_code, is_combination)
 
 
 def test_pip_item_no_retry(pip_item: PipItem):

--- a/tests/endpoints/test_purchases.py
+++ b/tests/endpoints/test_purchases.py
@@ -1,12 +1,12 @@
 import pytest
 
 from ikea_api.constants import Constants
-from ikea_api.endpoints.purchases import Purchases, Queries, _build_payload
+from ikea_api.endpoints.purchases import Purchases, Queries, build_payload
 from tests.conftest import EndpointTester
 
 
 def test_build_payload():
-    assert _build_payload("myoperation", "myquery", var1=1, var2=2) == {
+    assert build_payload("myoperation", "myquery", var1=1, var2=2) == {
         "operationName": "myoperation",
         "variables": {"var1": 1, "var2": 2},
         "query": "myquery",
@@ -23,7 +23,7 @@ def test_history(purchases: Purchases):
     skip = 1
     t = EndpointTester(purchases.history(take=take, skip=skip))
     req = t.prepare()
-    assert req.json == _build_payload("History", Queries.history, take=take, skip=skip)
+    assert req.json == build_payload("History", Queries.history, take=take, skip=skip)
 
     t.assert_json_returned()
 

--- a/tests/endpoints/test_purchases.py
+++ b/tests/endpoints/test_purchases.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ikea_api.constants import Constants
-from ikea_api.endpoints.purchases import API, Queries, _build_payload
+from ikea_api.endpoints.purchases import Purchases, Queries, _build_payload
 from tests.conftest import EndpointTester
 
 
@@ -15,10 +15,10 @@ def test_build_payload():
 
 @pytest.fixture
 def purchases(constants: Constants):
-    return API(constants, token="mytoken")  # nosec
+    return Purchases(constants, token="mytoken")  # nosec
 
 
-def test_history(purchases: API):
+def test_history(purchases: Purchases):
     take = 3
     skip = 1
     t = EndpointTester(purchases.history(take=take, skip=skip))
@@ -28,7 +28,7 @@ def test_history(purchases: API):
     t.assert_json_returned()
 
 
-def test_order_info_with_email(purchases: API):
+def test_order_info_with_email(purchases: Purchases):
     email = "mail@example.com"
 
     t = EndpointTester(purchases.order_info(order_number="", email=email))
@@ -43,7 +43,7 @@ def test_order_info_with_email(purchases: API):
     t.assert_json_returned()
 
 
-def test_order_info_no_email(purchases: API):
+def test_order_info_no_email(purchases: Purchases):
     order_number = "1111111111"
 
     t = EndpointTester(purchases.order_info(order_number=order_number))

--- a/tests/endpoints/test_search.py
+++ b/tests/endpoints/test_search.py
@@ -8,7 +8,7 @@ def test_search(constants: Constants):
     limit = 30
     types: list[search.SearchType] = ["PLANNER", "REFINED_SEARCHES"]
 
-    t = EndpointTester(search.API(constants).search(query, limit=limit, types=types))
+    t = EndpointTester(search.Search(constants).search(query, limit=limit, types=types))
     req = t.prepare()
 
     assert req.params

--- a/tests/endpoints/test_search.py
+++ b/tests/endpoints/test_search.py
@@ -1,14 +1,14 @@
 from ikea_api.constants import Constants
-from ikea_api.endpoints import search
+from ikea_api.endpoints.search import Search, SearchType
 from tests.conftest import EndpointTester
 
 
 def test_search(constants: Constants):
     query = "myquery"
     limit = 30
-    types: list[search.SearchType] = ["PLANNER", "REFINED_SEARCHES"]
+    types: list[SearchType] = ["PLANNER", "REFINED_SEARCHES"]
 
-    t = EndpointTester(search.Search(constants).search(query, limit=limit, types=types))
+    t = EndpointTester(Search(constants).search(query, limit=limit, types=types))
     req = t.prepare()
 
     assert req.params

--- a/tests/endpoints/test_stock.py
+++ b/tests/endpoints/test_stock.py
@@ -3,14 +3,14 @@ from typing import Any
 import pytest
 
 from ikea_api.constants import Constants
-from ikea_api.endpoints.stock import API
+from ikea_api.endpoints.stock import Stock
 from ikea_api.exceptions import ItemFetchError
 from tests.conftest import EndpointTester, MockResponseInfo
 
 
 def test_stock_prepare(constants: Constants):
     item_codes = ["11111111"]
-    t = EndpointTester(API(constants).get_stock(item_codes))
+    t = EndpointTester(Stock(constants).get_stock(item_codes))
     req = t.prepare()
 
     assert req.params
@@ -27,7 +27,7 @@ def test_stock_prepare(constants: Constants):
 )
 def test_stock_raises_without_item_code(constants: Constants, v: Any):
     item_code = "11111111"
-    t = EndpointTester(API(constants).get_stock([item_code]))
+    t = EndpointTester(Stock(constants).get_stock([item_code]))
 
     with pytest.raises(ItemFetchError) as exc:
         t.parse(MockResponseInfo(json_=v))
@@ -37,7 +37,7 @@ def test_stock_raises_without_item_code(constants: Constants, v: Any):
 
 def test_stock_raises_with_item_code(constants: Constants):
     item_code = "11111111"
-    t = EndpointTester(API(constants).get_stock([item_code]))
+    t = EndpointTester(Stock(constants).get_stock([item_code]))
     response = {
         "availabilities": None,
         "errors": [
@@ -59,5 +59,5 @@ def test_stock_raises_with_item_code(constants: Constants):
 
 def test_stock_passes(constants: Constants):
     item_code = "11111111"
-    t = EndpointTester(API(constants).get_stock([item_code]))
+    t = EndpointTester(Stock(constants).get_stock([item_code]))
     assert t.parse(MockResponseInfo(json_="ok")) == "ok"

--- a/tests/executors/test_httpx.py
+++ b/tests/executors/test_httpx.py
@@ -10,7 +10,7 @@ from ikea_api.executors.httpx import (
     HttpxResponseInfo,
     get_cached_session,
     get_session_from_info,
-    run,
+    run_async,
 )
 from tests.conftest import ExecutorContext
 
@@ -76,4 +76,4 @@ async def test_httpx_executor(
         return httpx.AsyncClient(headers=session.headers, transport=transport)
 
     monkeypatch.setattr(ikea_api.executors.httpx, "get_session_from_info", func)
-    await run(executor_context.func())
+    await run_async(executor_context.func())

--- a/tests/wrappers/parsers/test_item_ingka.py
+++ b/tests/wrappers/parsers/test_item_ingka.py
@@ -5,9 +5,9 @@ from typing import Any
 
 import pytest
 
+from ikea_api.constants import Constants
 from ikea_api.exceptions import ParsingError
 from ikea_api.wrappers.parsers.ingka_items import (
-    Constants,
     get_child_items,
     get_image_url,
     get_localised_communication,

--- a/tests/wrappers/parsers/test_item_ingka.py
+++ b/tests/wrappers/parsers/test_item_ingka.py
@@ -13,7 +13,7 @@ from ikea_api.wrappers.parsers.ingka_items import (
     get_localised_communication,
     get_name,
     get_weight,
-    main,
+    parse_ingka_items,
     parse_russian_product_name,
 )
 from tests.conftest import TestData
@@ -204,4 +204,4 @@ def test_get_child_items_success():
 
 @pytest.mark.parametrize("test_data_response", TestData.item_ingka)
 def test_main(constants: Constants, test_data_response: dict[str, Any]):
-    list(main(constants, test_data_response))
+    list(parse_ingka_items(constants, test_data_response))

--- a/tests/wrappers/parsers/test_item_iows.py
+++ b/tests/wrappers/parsers/test_item_iows.py
@@ -18,7 +18,7 @@ from ikea_api.wrappers.parsers.iows_items import (
     get_rid_of_dollars,
     get_url,
     get_weight,
-    main,
+    parse_iows_item,
     parse_weight,
 )
 from tests.conftest import TestData
@@ -240,4 +240,4 @@ def test_get_category_name_and_url_passes(constants: Constants):
 
 @pytest.mark.parametrize("test_data_response", TestData.item_iows)
 def test_main(constants: Constants, test_data_response: dict[str, Any]):
-    main(constants, test_data_response)
+    parse_iows_item(constants, test_data_response)

--- a/tests/wrappers/parsers/test_item_pip.py
+++ b/tests/wrappers/parsers/test_item_pip.py
@@ -10,7 +10,7 @@ from ikea_api.wrappers.parsers.pip_item import (
     CatalogRef,
     CatalogRefs,
     get_category_name_and_url,
-    main,
+    parse_pip_item,
 )
 from tests.conftest import TestData
 
@@ -32,4 +32,4 @@ def test_get_category_name_and_url_raises():
 
 @pytest.mark.parametrize("test_data_response", TestData.item_pip)
 def test_main(test_data_response: dict[str, Any]):
-    main(test_data_response)
+    parse_pip_item(test_data_response)

--- a/tests/wrappers/test_wrappers.py
+++ b/tests/wrappers/test_wrappers.py
@@ -11,9 +11,9 @@ import ikea_api.executors.requests
 import ikea_api.wrappers.wrappers
 from ikea_api.abc import EndpointInfo, RequestInfo, ResponseInfo
 from ikea_api.constants import Constants
-from ikea_api.endpoints import cart, purchases
-from ikea_api.endpoints.cart import convert_items
+from ikea_api.endpoints.cart import Cart, convert_items
 from ikea_api.endpoints.order_capture import convert_cart_to_checkout_items
+from ikea_api.endpoints.purchases import Purchases
 from ikea_api.executors.httpx import HttpxExecutor
 from ikea_api.executors.requests import RequestsExecutor
 from ikea_api.utils import parse_item_codes
@@ -67,7 +67,7 @@ def patch_httpx_executor(
 
 
 def test_get_purchase_history(monkeypatch: pytest.MonkeyPatch, constants: Constants):
-    api = purchases.Purchases(constants, token="mytoken")  # nosec
+    api = Purchases(constants, token="mytoken")  # nosec
     patch_requests_executor(
         monkeypatch, lambda _: MockResponseInfo(json_=TestData.purchases_history)
     )
@@ -76,7 +76,7 @@ def test_get_purchase_history(monkeypatch: pytest.MonkeyPatch, constants: Consta
 
 
 def test_get_purchase_info(monkeypatch: pytest.MonkeyPatch, constants: Constants):
-    api = purchases.Purchases(constants, token="mytoken")  # nosec
+    api = Purchases(constants, token="mytoken")  # nosec
     patch_requests_executor(
         monkeypatch,
         lambda _: MockResponseInfo(
@@ -88,7 +88,7 @@ def test_get_purchase_info(monkeypatch: pytest.MonkeyPatch, constants: Constants
 
 
 def test_add_items_to_cart(monkeypatch: pytest.MonkeyPatch, constants: Constants):
-    api = cart.Cart(constants, token="mytoken")  # nosec
+    api = Cart(constants, token="mytoken")  # nosec
     exp_items = [
         {"11111111": 2, "22222222": 1, "33333333": 4},
         {"11111111": 2, "33333333": 4},

--- a/tests/wrappers/test_wrappers.py
+++ b/tests/wrappers/test_wrappers.py
@@ -67,7 +67,7 @@ def patch_httpx_executor(
 
 
 def test_get_purchase_history(monkeypatch: pytest.MonkeyPatch, constants: Constants):
-    api = purchases.API(constants, token="mytoken")  # nosec
+    api = purchases.Purchases(constants, token="mytoken")  # nosec
     patch_requests_executor(
         monkeypatch, lambda _: MockResponseInfo(json_=TestData.purchases_history)
     )
@@ -76,7 +76,7 @@ def test_get_purchase_history(monkeypatch: pytest.MonkeyPatch, constants: Consta
 
 
 def test_get_purchase_info(monkeypatch: pytest.MonkeyPatch, constants: Constants):
-    api = purchases.API(constants, token="mytoken")  # nosec
+    api = purchases.Purchases(constants, token="mytoken")  # nosec
     patch_requests_executor(
         monkeypatch,
         lambda _: MockResponseInfo(
@@ -88,7 +88,7 @@ def test_get_purchase_info(monkeypatch: pytest.MonkeyPatch, constants: Constants
 
 
 def test_add_items_to_cart(monkeypatch: pytest.MonkeyPatch, constants: Constants):
-    api = cart.API(constants, token="mytoken")  # nosec
+    api = cart.Cart(constants, token="mytoken")  # nosec
     exp_items = [
         {"11111111": 2, "22222222": 1, "33333333": 4},
         {"11111111": 2, "33333333": 4},


### PR DESCRIPTION
v2.0.0 introducers lots of changes. One of them was getting rid of master `IKEA` object. 

The way _symbols_ were named (for example, each endpoint had class `API`) and how they was exported (`from ikea_api.endpoints.cart import API as Cart`) causes issues with autocompletion in IDEs (I use VS Code) and type checking.

This PR resolves the issue [the hard way]. 