### PR TITLE
Fix stock endpoint issues

### DIFF
--- a/src/ikea_api/endpoints/stock.py
+++ b/src/ikea_api/endpoints/stock.py
@@ -21,15 +21,18 @@ class Stock(BaseIkeaAPI):
         return SessionInfo(base_url=url, headers=headers)
 
     @endpoint(handlers=[handle_json_decode_error])
-    def get_stock(self, item_codes: list[str]) -> Endpoint[dict[str, Any]]:
-        params = {"itemNos": item_codes, "expand": "StoresList,Restocks,SalesLocations"}
+    def get_stock(self, item_code: str) -> Endpoint[dict[str, Any]]:
+        params = {
+            "itemNos": [item_code],
+            "expand": "StoresList,Restocks,SalesLocations",
+        }
         response = yield self._RequestInfo("GET", params=params)
 
         if "errors" not in response.json:
             return response.json
 
         try:
-            item_code = response.json["errors"][0]["details"]["itemNo"]
+            msg = response.json["errors"][0]["details"]["itemNo"]
         except (KeyError, TypeError, IndexError):
-            item_code = None
-        raise ItemFetchError(response, msg=item_code)
+            msg = None
+        raise ItemFetchError(response, msg=msg)

--- a/src/ikea_api/endpoints/stock.py
+++ b/src/ikea_api/endpoints/stock.py
@@ -4,8 +4,7 @@ from typing import Any
 
 from ikea_api.abc import Endpoint, SessionInfo, endpoint
 from ikea_api.base_ikea_api import BaseIkeaAPI
-from ikea_api.error_handlers import handle_json_decode_error
-from ikea_api.exceptions import ItemFetchError
+from ikea_api.error_handlers import handle_graphql_error, handle_json_decode_error
 
 
 class Stock(BaseIkeaAPI):
@@ -20,19 +19,11 @@ class Stock(BaseIkeaAPI):
         )
         return SessionInfo(base_url=url, headers=headers)
 
-    @endpoint(handlers=[handle_json_decode_error])
+    @endpoint(handlers=[handle_json_decode_error, handle_graphql_error])
     def get_stock(self, item_code: str) -> Endpoint[dict[str, Any]]:
         params = {
             "itemNos": [item_code],
             "expand": "StoresList,Restocks,SalesLocations",
         }
         response = yield self._RequestInfo("GET", params=params)
-
-        if "errors" not in response.json:
-            return response.json
-
-        try:
-            msg = response.json["errors"][0]["details"]["itemNo"]
-        except (KeyError, TypeError, IndexError):
-            msg = None
-        raise ItemFetchError(response, msg=msg)
+        return response.json

--- a/tests/endpoints/test_stock.py
+++ b/tests/endpoints/test_stock.py
@@ -9,12 +9,12 @@ from tests.conftest import EndpointTester, MockResponseInfo
 
 
 def test_stock_prepare(constants: Constants):
-    item_codes = ["11111111"]
-    t = EndpointTester(Stock(constants).get_stock(item_codes))
+    item_code = "11111111"
+    t = EndpointTester(Stock(constants).get_stock(item_code))
     req = t.prepare()
 
     assert req.params
-    assert req.params["itemNos"] == item_codes
+    assert req.params["itemNos"] == [item_code]
 
 
 @pytest.mark.parametrize(
@@ -27,7 +27,7 @@ def test_stock_prepare(constants: Constants):
 )
 def test_stock_raises_without_item_code(constants: Constants, v: Any):
     item_code = "11111111"
-    t = EndpointTester(Stock(constants).get_stock([item_code]))
+    t = EndpointTester(Stock(constants).get_stock(item_code))
 
     with pytest.raises(ItemFetchError) as exc:
         t.parse(MockResponseInfo(json_=v))
@@ -37,7 +37,7 @@ def test_stock_raises_without_item_code(constants: Constants, v: Any):
 
 def test_stock_raises_with_item_code(constants: Constants):
     item_code = "11111111"
-    t = EndpointTester(Stock(constants).get_stock([item_code]))
+    t = EndpointTester(Stock(constants).get_stock(item_code))
     response = {
         "availabilities": None,
         "errors": [
@@ -59,5 +59,5 @@ def test_stock_raises_with_item_code(constants: Constants):
 
 def test_stock_passes(constants: Constants):
     item_code = "11111111"
-    t = EndpointTester(Stock(constants).get_stock([item_code]))
+    t = EndpointTester(Stock(constants).get_stock(item_code))
     assert t.parse(MockResponseInfo(json_="ok")) == "ok"

--- a/tests/endpoints/test_stock.py
+++ b/tests/endpoints/test_stock.py
@@ -1,10 +1,5 @@
-from typing import Any
-
-import pytest
-
 from ikea_api.constants import Constants
 from ikea_api.endpoints.stock import Stock
-from ikea_api.exceptions import ItemFetchError
 from tests.conftest import EndpointTester, MockResponseInfo
 
 
@@ -17,47 +12,7 @@ def test_stock_prepare(constants: Constants):
     assert req.params["itemNos"] == [item_code]
 
 
-@pytest.mark.parametrize(
-    "v",
-    (
-        {"errors": {}},
-        {"errors": []},
-        {"errors": [{"code": 404, "message": "Not found", "details": []}]},
-    ),
-)
-def test_stock_raises_without_item_code(constants: Constants, v: Any):
-    item_code = "11111111"
-    t = EndpointTester(Stock(constants).get_stock(item_code))
-
-    with pytest.raises(ItemFetchError) as exc:
-        t.parse(MockResponseInfo(json_=v))
-
-    assert item_code not in str(exc.value.args)
-
-
-def test_stock_raises_with_item_code(constants: Constants):
-    item_code = "11111111"
-    t = EndpointTester(Stock(constants).get_stock(item_code))
-    response = {
-        "availabilities": None,
-        "errors": [
-            {
-                "code": 404,
-                "message": "Not found",
-                "details": {
-                    "classUnitCode": "RU",
-                    "classUnitType": "RU",
-                    "itemNo": item_code,
-                },
-            }
-        ],
-    }
-    with pytest.raises(ItemFetchError) as exc:
-        t.parse(MockResponseInfo(json_=response))
-    assert item_code in exc.value.args
-
-
-def test_stock_passes(constants: Constants):
+def test_stock_parse(constants: Constants):
     item_code = "11111111"
     t = EndpointTester(Stock(constants).get_stock(item_code))
     assert t.parse(MockResponseInfo(json_="ok")) == "ok"


### PR DESCRIPTION
- API doesn't work correctly when passing multiple item codes — fixed this.
- Since there's `errors` key in failed response, GraphQL error handler will do. Also there's really no point of raising ItemFetchError: one request — one item, and this exception is relevant to _item_ endpoints, not stock.

Reference: https://github.com/vrslev/ikea-api-client/pull/92#issuecomment-1046350171